### PR TITLE
Support older git without -C

### DIFF
--- a/rush
+++ b/rush
@@ -1041,7 +1041,7 @@ rush_pull_command() {
   
     if [[ -d "$repo_path/.git" ]]; then
       echo "pull $(green "$repo")"
-      git -C "$repo_path" pull
+      ( cd "$repo_path" && git pull )
     else
       echo "skip $(blue "$repo") (not a git repo)"
     fi
@@ -1071,7 +1071,7 @@ rush_push_command() {
   
     if [[ -d "$repo_path/.git" ]]; then
       echo "push $(green "$repo")"
-      git -C "$repo_path" add . --all && git -C "$repo_path" commit -am "$message" && git -C "$repo_path" push
+      ( cd "$repo_path" && git add . --all && git commit -am "$message" && git push )
     else
       echo "skip $(blue "$repo") (not a git repo)"
     fi

--- a/src/pull_command.sh
+++ b/src/pull_command.sh
@@ -6,7 +6,7 @@ pull_repo() {
 
   if [[ -d "$repo_path/.git" ]]; then
     echo "pull $(green "$repo")"
-    git -C "$repo_path" pull
+    ( cd "$repo_path" && git pull )
   else
     echo "skip $(blue "$repo") (not a git repo)"
   fi

--- a/src/push_command.sh
+++ b/src/push_command.sh
@@ -8,7 +8,7 @@ push_repo() {
 
   if [[ -d "$repo_path/.git" ]]; then
     echo "push $(green "$repo")"
-    git -C "$repo_path" add . --all && git -C "$repo_path" commit -am "$message" && git -C "$repo_path" push
+    ( cd "$repo_path" && git add . --all && git commit -am "$message" && git push )
   else
     echo "skip $(blue "$repo") (not a git repo)"
   fi


### PR DESCRIPTION
Older git does not have the -C command that allows running git as if it was run in another folder.
This PR changes the two use cases of this option, to use good old `cd` instead.