### PR TITLE
Fix search command to ignore dot paths

### DIFF
--- a/rush
+++ b/rush
@@ -1127,7 +1127,7 @@ rush_search_command() {
     [[ "$repo" != "default" ]] && prefix="$repo:"
   
     # Search directories matching search text
-    find "$repo_path" -type d | grep --color=always "$text" | \
+    find "$repo_path" -type d -not -path '*/\.*' | grep --color=always "$text" | \
       sed "s#${repo_path}/#${prefix}#g" | sed 's#/info##'
   
     # Search info files matching search text

--- a/src/search_command.sh
+++ b/src/search_command.sh
@@ -10,7 +10,7 @@ search_repo() {
   [[ "$repo" != "default" ]] && prefix="$repo:"
 
   # Search directories matching search text
-  find "$repo_path" -type d | grep --color=always "$text" | \
+  find "$repo_path" -type d -not -path '*/\.*' | grep --color=always "$text" | \
     sed "s#${repo_path}/#${prefix}#g" | sed 's#/info##'
 
   # Search info files matching search text


### PR DESCRIPTION
When searching for folders that happen to exist under the `.git` folder (for example, `rush search fd`, then these folders would also be displayed.

This PR updates the search command to ignore anything that starts with a dot.