### PR TITLE
Add USER_CWD variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,9 @@ To create a repository manually, follow these steps:
 5. Note that the `main` and `undo` scripts are executed in the same folder it
    lives in, so you can copy files from the package's directory to wherever
    they need to be.
-6. The `main` and `undo` scripts can be written in any language, as long as
+6. If you need to read/write files in the user's current direcotory, use the
+   `$USER_CWD` environment variable.
+7. The `main` and `undo` scripts can be written in any language, as long as
    they have a shebang line.
 
 

--- a/rush
+++ b/rush
@@ -952,6 +952,7 @@ rush_get_command() {
   # Run the script (make it executable if it isnt first)
   export REPO="$repo"
   export REPO_PATH="$repo_path"
+  [[ -z "$USER_CWD" ]] && export USER_CWD="$PWD"
   echo "run $(green "$repo:$package")"
   [[ -x "$script" ]] || chmod u+x "$script"
   cd "$package_path"
@@ -982,6 +983,7 @@ rush_undo_command() {
   # Run the script (make it executable if it isnt first)
   export REPO="$repo"
   export REPO_PATH="$repo_path"
+  [[ -z "$USER_CWD" ]] && export USER_CWD="$PWD"
   echo "undo $(green "$repo:$package")"
   [[ -x "$script" ]] || chmod u+x "$script"
   cd "$package_path"

--- a/sample-repo/download/main
+++ b/sample-repo/download/main
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
-cp somefile $OLDPWD/somefile
+cp somefile $USER_CWD/somefile
 echo "Saved 'somefile' in the current directory"

--- a/sample-repo/download/undo
+++ b/sample-repo/download/undo
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
-rm $OLDPWD/somefile
+rm $USER_CWD/somefile
 echo "Removed 'somefile' from the current directory"

--- a/sample-repo/package-in-package/one/main
+++ b/sample-repo/package-in-package/one/main
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-echo "What's the rush?"
+echo "In one/main"
+echo "PWD:       $PWD"
 echo "REPO:      $REPO"
 echo "REPO_PATH: $REPO_PATH"
 echo "USER_CWD:  $USER_CWD"
+
+rush $REPO:package-in-package/two

--- a/sample-repo/package-in-package/two/main
+++ b/sample-repo/package-in-package/two/main
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-echo "What's the rush?"
+echo "In two/main"
+echo "PWD:       $PWD"
 echo "REPO:      $REPO"
 echo "REPO_PATH: $REPO_PATH"
 echo "USER_CWD:  $USER_CWD"

--- a/src/get_command.sh
+++ b/src/get_command.sh
@@ -19,6 +19,7 @@ script=$package_path/main
 # Run the script (make it executable if it isnt first)
 export REPO="$repo"
 export REPO_PATH="$repo_path"
+[[ -z "$USER_CWD" ]] && export USER_CWD="$PWD"
 echo "run $(green "$repo:$package")"
 [[ -x "$script" ]] || chmod u+x "$script"
 cd "$package_path"

--- a/src/undo_command.sh
+++ b/src/undo_command.sh
@@ -19,6 +19,7 @@ script=$package_path/undo
 # Run the script (make it executable if it isnt first)
 export REPO="$repo"
 export REPO_PATH="$repo_path"
+[[ -z "$USER_CWD" ]] && export USER_CWD="$PWD"
 echo "undo $(green "$repo:$package")"
 [[ -x "$script" ]] || chmod u+x "$script"
 cd "$package_path"

--- a/test/approvals/rush_add_ls
+++ b/test/approvals/rush_add_ls
@@ -3,3 +3,4 @@ download
 hello
 hidden
 nested
+package-in-package

--- a/test/approvals/rush_edit_hello
+++ b/test/approvals/rush_edit_hello
@@ -2,3 +2,4 @@
 echo "What's the rush?"
 echo "REPO:      $REPO"
 echo "REPO_PATH: $REPO_PATH"
+echo "USER_CWD:  $USER_CWD"

--- a/test/approvals/rush_get_hello
+++ b/test/approvals/rush_get_hello
@@ -2,3 +2,4 @@ run [32mdefault:hello[0m
 What's the rush?
 REPO:      default
 REPO_PATH: /root/rush-repos/sample-repo
+USER_CWD:  /test

--- a/test/approvals/rush_get_package_in_package_one
+++ b/test/approvals/rush_get_package_in_package_one
@@ -1,0 +1,12 @@
+run [32mdefault:package-in-package/one[0m
+In one/main
+PWD:       /root/rush-repos/sample-repo/package-in-package/one
+REPO:      default
+REPO_PATH: /root/rush-repos/sample-repo
+USER_CWD:  /test
+run [32mdefault:package-in-package/two[0m
+In two/main
+PWD:       /root/rush-repos/sample-repo/package-in-package/two
+REPO:      default
+REPO_PATH: /root/rush-repos/sample-repo
+USER_CWD:  /test

--- a/test/approvals/rush_get_sample_hello
+++ b/test/approvals/rush_get_sample_hello
@@ -2,3 +2,4 @@ run [32msample:hello[0m
 What's the rush?
 REPO:      sample
 REPO_PATH: /root/rush-repos/sample-repo
+USER_CWD:  /test

--- a/test/approvals/rush_hello
+++ b/test/approvals/rush_hello
@@ -2,3 +2,4 @@ run [32mdefault:hello[0m
 What's the rush?
 REPO:      default
 REPO_PATH: /root/rush-repos/sample-repo
+USER_CWD:  /test

--- a/test/approvals/rush_info_download_x
+++ b/test/approvals/rush_info_download_x
@@ -4,11 +4,11 @@ Shows how a script can copy files from its own folder
 [32mmain:[0m
 #!/usr/bin/env bash
 set -e
-cp somefile $OLDPWD/somefile
+cp somefile $USER_CWD/somefile
 echo "Saved 'somefile' in the current directory"
 
 [32mundo:[0m
 #!/usr/bin/env bash
 set -e
-rm $OLDPWD/somefile
+rm $USER_CWD/somefile
 echo "Removed 'somefile' from the current directory"

--- a/test/approvals/rush_info_hello_extended
+++ b/test/approvals/rush_info_hello_extended
@@ -13,3 +13,4 @@ This info file can be accessed by running
 echo "What's the rush?"
 echo "REPO:      $REPO"
 echo "REPO_PATH: $REPO_PATH"
+echo "USER_CWD:  $USER_CWD"

--- a/test/test.sh
+++ b/test/test.sh
@@ -3,91 +3,92 @@
 
 source approvals.bash
 
-# before
+# before all
 git config --global user.email "approval@tester.com"
 git config --global user.name "Approval Tester"
 
-# usage
-approve "rush"
-approve "rush --help"
+describe "usage"
+  approve "rush"
+  approve "rush --help"
 
-# add
-approve "rush add"
-approve "rush add -h"
-approve "rush add sample ~/rush-repos/sample-repo"
-approve "ls ~/rush-repos/sample-repo" "rush_add_ls"
+describe "add"
+  approve "rush add"
+  approve "rush add -h"
+  approve "rush add sample ~/rush-repos/sample-repo"
+  approve "ls ~/rush-repos/sample-repo" "rush_add_ls"
 
-# clone
-rm -rf /root/rush-repos/dannyben
-approve "rush clone"
-approve "rush clone -h"
-approve "rush clone dannyben"
+describe "clone"
+  rm -rf /root/rush-repos/dannyben
+  approve "rush clone"
+  approve "rush clone -h"
+  approve "rush clone dannyben"
 
-# config
-approve "rush config"
-approve "rush config -h"
+describe "config"
+  approve "rush config"
+  approve "rush config -h"
 
-# default
-approve "rush default"
-approve "rush default -h"
-approve "rush default sample"
+describe "default"
+  approve "rush default"
+  approve "rush default -h"
+  approve "rush default sample"
 
-# get
-approve "rush add sample ~/rush-repos/sample-repo"
-approve "rush get"
-approve "rush get -h"
-approve "rush get hello"
-approve "rush get download"
-approve "rush get sample:hello"
-approve "rush hello"
+describe "get"
+  approve "rush add sample ~/rush-repos/sample-repo"
+  approve "rush get"
+  approve "rush get -h"
+  approve "rush get hello"
+  approve "rush get download"
+  approve "rush get sample:hello"
+  approve "rush hello"
+  approve "rush get package-in-package/one"
 
-# undo
-approve "rush undo"
-approve "rush undo -h"
-approve "rush undo download"
-approve "rush undo sample:download"
+describe "undo"
+  approve "rush undo"
+  approve "rush undo -h"
+  approve "rush undo download"
+  approve "rush undo sample:download"
 
-# info
-approve "rush info"
-approve "rush info -h"
-approve "rush info hello"
-approve "rush info sample:hello"
-approve "rush info hello --extended"
-approve "rush info download -x"
+describe "info"
+  approve "rush info"
+  approve "rush info -h"
+  approve "rush info hello"
+  approve "rush info sample:hello"
+  approve "rush info hello --extended"
+  approve "rush info download -x"
 
-# pull
-approve "rush pull"
-approve "rush pull -h"
+describe "pull"
+  approve "rush pull"
+  approve "rush pull -h"
 
-# push
-approve "rush push"
-approve "rush push -h"
+describe "push"
+  approve "rush push"
+  approve "rush push -h"
 
-# remove
-approve "rush remove"
-approve "rush remove -h"
-approve "rush remove dannyben"
+describe "remove"
+  approve "rush remove"
+  approve "rush remove -h"
+  approve "rush remove dannyben"
 
-# list
-approve "rush list -h"
-approve "rush list"
-approve "rush list --simple"
-approve "rush list hello"
-approve "rush list sample"
-approve "rush list nested"
-approve "rush list sample:nested"
-approve "rush list no-such-package"
+describe "list"
+  approve "rush list -h"
+  approve "rush list"
+  approve "rush list --simple"
+  approve "rush list hello"
+  approve "rush list sample"
+  approve "rush list nested"
+  approve "rush list sample:nested"
+  approve "rush list no-such-package"
 
-# search
-approve "rush search"
-approve "rush search -h"
-approve "rush search running"
-apk del grep >/dev/null 2>&1
-approve "rush search busybox-error"
+describe "search"
+  approve "rush search"
+  approve "rush search -h"
+  approve "rush search running"
+  apk del grep >/dev/null 2>&1
+  approve "rush search busybox-error"
 
-# edit
-export EDITOR=cat
-approve "rush edit"
-approve "rush edit -h"
-approve "rush edit hello"
-approve "rush edit hello info"
+describe "edit"
+  export EDITOR=cat
+  approve "rush edit"
+  approve "rush edit -h"
+  approve "rush edit hello"
+  approve "rush edit hello info"


### PR DESCRIPTION
Before this PR, the `main` and `undo` scripts could use the standard `$OLDPWD` to determine the directory from which the script was executed.

But, if a package calls another package (using `rush get $REPO:second-package`), there will be no way to access the user's CWD, since the variable will hold the path to the first package.

This PR adds a `$USER_CWD` variable that will only be populated on the first rush run, so subsequent packages will not override it. See the package-in-package example in the sample-repo folder.

In addition, upgrade `approvals.bash` to the latest version.