### PR TITLE
Non interactive setup script

### DIFF
--- a/rush
+++ b/rush
@@ -1185,7 +1185,7 @@ parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -1335,7 +1335,7 @@ rush_add_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -1400,7 +1400,7 @@ rush_remove_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -1454,7 +1454,7 @@ rush_clone_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -1529,7 +1529,7 @@ rush_pull_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -1576,7 +1576,7 @@ rush_push_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -1635,7 +1635,7 @@ rush_config_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -1683,7 +1683,7 @@ rush_default_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -1737,7 +1737,7 @@ rush_get_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -1791,7 +1791,7 @@ rush_undo_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -1845,7 +1845,7 @@ rush_info_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -1905,7 +1905,7 @@ rush_list_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -1958,7 +1958,7 @@ rush_search_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )
@@ -2012,7 +2012,7 @@ rush_edit_parse_requirements() {
   case "$1" in
   --version | -v )
     version_command
-    exit 1
+    exit
     ;;
   
   --help | -h )

--- a/setup
+++ b/setup
@@ -1,30 +1,21 @@
 #!/usr/bin/env bash
-echo "This operation will download the rush bash script to /usr/local/bin/rush."
-printf "Continue? [yN] "
-read answer
+echo "Downloading to /usr/local/bin/rush"
 
-if [[ $answer =~ [Yy] ]]; then
-  echo ""
-  echo "Downloading from github.com/DannyBen/rush-cli..."
+curl_command="curl -s https://raw.githubusercontent.com/DannyBen/rush-cli/master/rush > /usr/local/bin/rush"
 
-  CURL_COMMAND="curl -s https://raw.githubusercontent.com/DannyBen/rush-cli/master/rush > /usr/local/bin/rush"
-
-  if [[ $EUID -ne 0 ]]; then
-    # not root, need sudo
-    sudo bash -c "$CURL_COMMAND"
-    sudo chmod a+x /usr/local/bin/rush
-  else
-    # root
-    bash -c "$CURL_COMMAND"
-    chmod a+x /usr/local/bin/rush
-  fi
-
-  if type rush > /dev/null; then
-    echo "Done. Type 'rush --help' for more info."
-  else
-    echo "Failed downloading."
-    exit 1
-  fi
+if [[ $EUID -ne 0 ]]; then
+  # not root, need sudo
+  sudo bash -c "$curl_command"
+  sudo chmod a+x /usr/local/bin/rush
 else
-  echo "Aborting"
+  # root
+  bash -c "$curl_command"
+  chmod a+x /usr/local/bin/rush
+fi
+
+if type rush > /dev/null; then
+  echo "Done. Type 'rush --help' for more info."
+else
+  echo "Failed downloading."
+  exit 1
 fi

--- a/test/test.sh
+++ b/test/test.sh
@@ -92,3 +92,5 @@ describe "edit"
   approve "rush edit -h"
   approve "rush edit hello"
   approve "rush edit hello info"
+
+green "All OK"


### PR DESCRIPTION
- Update the setup script so it no longer asks before downloading, to allow running it in automation.
- Generate with bashly 0.3.6, so that the `--version` flag exits with 0 instead of 1.