### PR TITLE
Regenerate with bashly 0.3.8

### DIFF
--- a/rush
+++ b/rush
@@ -18,7 +18,7 @@ rush_usage() {
   fi
 
   printf "Usage:\n"
-  printf "  rush [command] [options]\n"
+  printf "  rush [command]\n"
   printf "  rush [command] --help | -h\n"
   printf "  rush --version | -v\n"
   echo
@@ -79,7 +79,7 @@ rush_add_usage() {
   echo
 
   printf "Usage:\n"
-  printf "  rush add REPO PATH [options]\n"
+  printf "  rush add REPO PATH\n"
   printf "  rush add --help | -h\n"
   echo
 
@@ -128,7 +128,7 @@ rush_remove_usage() {
   echo
 
   printf "Usage:\n"
-  printf "  rush remove REPO [options]\n"
+  printf "  rush remove REPO\n"
   printf "  rush remove --help | -h\n"
   echo
 
@@ -226,7 +226,7 @@ rush_pull_usage() {
   echo
 
   printf "Usage:\n"
-  printf "  rush pull [REPO] [options]\n"
+  printf "  rush pull [REPO]\n"
   printf "  rush pull --help | -h\n"
   echo
 
@@ -331,7 +331,7 @@ rush_default_usage() {
   fi
 
   printf "Usage:\n"
-  printf "  rush default REPO [options]\n"
+  printf "  rush default REPO\n"
   printf "  rush default --help | -h\n"
   echo
 
@@ -375,7 +375,7 @@ rush_get_usage() {
   echo
 
   printf "Usage:\n"
-  printf "  rush get PACKAGE [options]\n"
+  printf "  rush get PACKAGE\n"
   printf "  rush get --help | -h\n"
   echo
 
@@ -420,7 +420,7 @@ rush_undo_usage() {
   echo
 
   printf "Usage:\n"
-  printf "  rush undo PACKAGE [options]\n"
+  printf "  rush undo PACKAGE\n"
   printf "  rush undo --help | -h\n"
   echo
 
@@ -562,7 +562,7 @@ rush_search_usage() {
   echo
 
   printf "Usage:\n"
-  printf "  rush search TEXT [options]\n"
+  printf "  rush search TEXT\n"
   printf "  rush search --help | -h\n"
   echo
 
@@ -598,7 +598,7 @@ rush_edit_usage() {
   echo
 
   printf "Usage:\n"
-  printf "  rush edit PACKAGE [FILE] [options]\n"
+  printf "  rush edit PACKAGE [FILE]\n"
   printf "  rush edit --help | -h\n"
   echo
 
@@ -1365,7 +1365,7 @@ rush_add_parse_requirements() {
     args[repo]=$1
     shift
   else
-    printf "missing required argument: REPO\nusage: rush add REPO PATH [options]\n"
+    printf "missing required argument: REPO\nusage: rush add REPO PATH\n"
     exit 1
   fi
   
@@ -1373,7 +1373,7 @@ rush_add_parse_requirements() {
     args[path]=$1
     shift
   else
-    printf "missing required argument: PATH\nusage: rush add REPO PATH [options]\n"
+    printf "missing required argument: PATH\nusage: rush add REPO PATH\n"
     exit 1
   fi
   # :command.required_flags_filter
@@ -1431,7 +1431,7 @@ rush_remove_parse_requirements() {
     args[repo]=$1
     shift
   else
-    printf "missing required argument: REPO\nusage: rush remove REPO [options]\n"
+    printf "missing required argument: REPO\nusage: rush remove REPO\n"
     exit 1
   fi
   # :command.required_flags_filter
@@ -1725,7 +1725,7 @@ rush_default_parse_requirements() {
     args[repo]=$1
     shift
   else
-    printf "missing required argument: REPO\nusage: rush default REPO [options]\n"
+    printf "missing required argument: REPO\nusage: rush default REPO\n"
     exit 1
   fi
   # :command.required_flags_filter
@@ -1780,7 +1780,7 @@ rush_get_parse_requirements() {
     args[package]=$1
     shift
   else
-    printf "missing required argument: PACKAGE\nusage: rush get PACKAGE [options]\n"
+    printf "missing required argument: PACKAGE\nusage: rush get PACKAGE\n"
     exit 1
   fi
   # :command.required_flags_filter
@@ -1835,7 +1835,7 @@ rush_undo_parse_requirements() {
     args[package]=$1
     shift
   else
-    printf "missing required argument: PACKAGE\nusage: rush undo PACKAGE [options]\n"
+    printf "missing required argument: PACKAGE\nusage: rush undo PACKAGE\n"
     exit 1
   fi
   # :command.required_flags_filter
@@ -2005,7 +2005,7 @@ rush_search_parse_requirements() {
     args[text]=$1
     shift
   else
-    printf "missing required argument: TEXT\nusage: rush search TEXT [options]\n"
+    printf "missing required argument: TEXT\nusage: rush search TEXT\n"
     exit 1
   fi
   # :command.required_flags_filter
@@ -2060,7 +2060,7 @@ rush_edit_parse_requirements() {
     args[package]=$1
     shift
   else
-    printf "missing required argument: PACKAGE\nusage: rush edit PACKAGE [FILE] [options]\n"
+    printf "missing required argument: PACKAGE\nusage: rush edit PACKAGE [FILE]\n"
     exit 1
   fi
   # :command.required_flags_filter

--- a/test/approvals/rush
+++ b/test/approvals/rush
@@ -1,7 +1,7 @@
 rush - Personal package manager
 
 Usage:
-  rush [command] [options]
+  rush [command]
   rush [command] --help | -h
   rush --version | -v
 

--- a/test/approvals/rush_add
+++ b/test/approvals/rush_add
@@ -1,2 +1,2 @@
 missing required argument: REPO
-usage: rush add REPO PATH [options]
+usage: rush add REPO PATH

--- a/test/approvals/rush_add_h
+++ b/test/approvals/rush_add_h
@@ -6,7 +6,7 @@ rush add
 Shortcut: a
 
 Usage:
-  rush add REPO PATH [options]
+  rush add REPO PATH
   rush add --help | -h
 
 Options:

--- a/test/approvals/rush_default
+++ b/test/approvals/rush_default
@@ -1,2 +1,2 @@
 missing required argument: REPO
-usage: rush default REPO [options]
+usage: rush default REPO

--- a/test/approvals/rush_default_h
+++ b/test/approvals/rush_default_h
@@ -5,7 +5,7 @@ rush default
   configuration file, and copies the path from the provided repo.
 
 Usage:
-  rush default REPO [options]
+  rush default REPO
   rush default --help | -h
 
 Options:

--- a/test/approvals/rush_edit
+++ b/test/approvals/rush_edit
@@ -1,2 +1,2 @@
 missing required argument: PACKAGE
-usage: rush edit PACKAGE [FILE] [options]
+usage: rush edit PACKAGE [FILE]

--- a/test/approvals/rush_edit_h
+++ b/test/approvals/rush_edit_h
@@ -3,7 +3,7 @@ rush edit - Edit package files
 Shortcut: e
 
 Usage:
-  rush edit PACKAGE [FILE] [options]
+  rush edit PACKAGE [FILE]
   rush edit --help | -h
 
 Options:

--- a/test/approvals/rush_get
+++ b/test/approvals/rush_get
@@ -1,2 +1,2 @@
 missing required argument: PACKAGE
-usage: rush get PACKAGE [options]
+usage: rush get PACKAGE

--- a/test/approvals/rush_get_h
+++ b/test/approvals/rush_get_h
@@ -6,7 +6,7 @@ rush get
 Shortcut: g
 
 Usage:
-  rush get PACKAGE [options]
+  rush get PACKAGE
   rush get --help | -h
 
 Options:

--- a/test/approvals/rush_help
+++ b/test/approvals/rush_help
@@ -1,7 +1,7 @@
 rush - Personal package manager
 
 Usage:
-  rush [command] [options]
+  rush [command]
   rush [command] --help | -h
   rush --version | -v
 

--- a/test/approvals/rush_pull_h
+++ b/test/approvals/rush_pull_h
@@ -3,7 +3,7 @@ rush pull - Git pull one or all repositories
 Shortcut: p
 
 Usage:
-  rush pull [REPO] [options]
+  rush pull [REPO]
   rush pull --help | -h
 
 Options:

--- a/test/approvals/rush_remove
+++ b/test/approvals/rush_remove
@@ -1,2 +1,2 @@
 missing required argument: REPO
-usage: rush remove REPO [options]
+usage: rush remove REPO

--- a/test/approvals/rush_remove_h
+++ b/test/approvals/rush_remove_h
@@ -6,7 +6,7 @@ rush remove
 Shortcut: r
 
 Usage:
-  rush remove REPO [options]
+  rush remove REPO
   rush remove --help | -h
 
 Options:

--- a/test/approvals/rush_search
+++ b/test/approvals/rush_search
@@ -1,2 +1,2 @@
 missing required argument: TEXT
-usage: rush search TEXT [options]
+usage: rush search TEXT

--- a/test/approvals/rush_search_h
+++ b/test/approvals/rush_search_h
@@ -3,7 +3,7 @@ rush search - Search in package names and info files
 Shortcut: s
 
 Usage:
-  rush search TEXT [options]
+  rush search TEXT
   rush search --help | -h
 
 Options:

--- a/test/approvals/rush_undo
+++ b/test/approvals/rush_undo
@@ -1,2 +1,2 @@
 missing required argument: PACKAGE
-usage: rush undo PACKAGE [options]
+usage: rush undo PACKAGE

--- a/test/approvals/rush_undo_h
+++ b/test/approvals/rush_undo_h
@@ -6,7 +6,7 @@ rush undo
 Shortcut: u
 
 Usage:
-  rush undo PACKAGE [options]
+  rush undo PACKAGE
   rush undo --help | -h
 
 Options:


### PR DESCRIPTION
Regenerate script with bashly 0.3.8, which removes the `[options]` usage marker unless there are actually options (flags) for the command.