### PR TITLE
Add rush clone --ignore and rueh get --clone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-RUN apk --no-cache add bash git diffutils grep
+RUN apk --no-cache add bash git diffutils grep curl
 
 ENV PS1 "\n\n>> rush \W \$ "
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ _  /     /_/    \__,_/ /____/ /_/ /_/
 /_/      Personal Package Manager
 ```
 
-![Version](https://img.shields.io/badge/version-0.5.0-blue.svg)
+![Version](https://img.shields.io/badge/version-0.5.1-blue.svg)
 [![Build Status](https://github.com/DannyBen/rush-cli/workflows/Test/badge.svg)](https://github.com/DannyBen/rush-cli/actions?query=workflow%3ATest)
 
 </div>
@@ -33,11 +33,16 @@ you install things.
 Rush was developed using the [Bashly Command Line Framework][bashly].
 
 
-Installation
+Prerequisites
 --------------------------------------------------
 
-> Note that rush requires bash 4.0 or higher (`brew install bash` on mac).
+- Bash 4.0 or higher (`brew install bash` on mac).
+- curl 
+- git
 
+
+Installation
+--------------------------------------------------
 
 ### Installing using the setup script
 
@@ -50,7 +55,7 @@ You can either install the latest version, or a specific version
 $ bash <(curl -s https://raw.githubusercontent.com/DannyBen/rush-cli/master/setup)
 
 # Or, install a specific version
-$ bash <(curl -s https://raw.githubusercontent.com/DannyBen/rush-cli/v0.5.0/setup)
+$ bash <(curl -s https://raw.githubusercontent.com/DannyBen/rush-cli/v0.5.1/setup)
 ```
 
 Feel free to inspect the [setup script](setup) before running.

--- a/rush
+++ b/rush
@@ -2338,7 +2338,7 @@ rush_edit_parse_requirements() {
 
 # :command.initialize
 initialize() {
-  version="0.5.0"
+  version="0.5.1"
   long_usage=''
   set -e  
 

--- a/rush
+++ b/rush
@@ -392,7 +392,7 @@ rush_get_usage() {
   echo
 
   printf "Usage:\n"
-  printf "  rush get PACKAGE\n"
+  printf "  rush get PACKAGE [options]\n"
   printf "  rush get --help | -h\n"
   echo
 
@@ -402,7 +402,11 @@ rush_get_usage() {
     echo "  --help, -h"
     printf "    Show this help\n"
     echo
-
+    # :command.usage_flags
+    # :flag.usage
+    echo "  --clone, -c"
+    printf "    Clone the repository if it is not found locally\n    This flag will look for a GitHub user with the same name as the\n    repository, and attempt to clone their rush-repo repository.\n"
+    echo
     # :command.usage_args
     printf "Arguments:\n"
     
@@ -865,6 +869,13 @@ config_has_key() {
   [[ $(config_get "$1") ]]
 }
 
+# :src/lib/github_repo_exist.sh
+# if github_repo_exist dannyben/rush-cli ; then ...
+github_repo_exist() {
+  repo="$1"
+  curl -s -o /dev/null -I -w "%{http_code}"  "https://api.github.com/repos/$repo" | grep 200 > /dev/null
+}
+
 # :src/lib/is_busybox_grep.sh
 is_busybox_grep() {
   grep --version 2>&1 /dev/null | grep -i busybox > /dev/null 2>&1
@@ -952,10 +963,10 @@ rush_clone_command() {
     say "clone" "skipping $repo_name (exists)"
   
   else
-    set -e
-  
     # Clone
     say "clone" "$repo_url"
+    github_repo_exist "$repo_id" || abort "cannot find $repo_id on github"
+  
     if [[ $full ]]; then
       git clone "$repo_url" "$path"
     else
@@ -1059,10 +1070,16 @@ rush_get_command() {
   # Collect variables
   package=${args[package]}
   repo="default"
+  clone=${args[--clone]}
   
   if [[ $package =~ (.*):(.*) ]]; then
     repo=${BASH_REMATCH[1]}
     package=${BASH_REMATCH[2]}
+  fi
+  
+  if ! config_has_key "$repo" && [[ $clone ]] && [[ $repo != 'default' ]]; then
+    say "get" "repo $repo does not exist, attempting clone"
+    rush clone "$repo"
   fi
   
   repo_path=$(config_get "$repo")
@@ -1934,7 +1951,7 @@ rush_get_parse_requirements() {
     args[package]=$1
     shift
   else
-    printf "missing required argument: PACKAGE\nusage: rush get PACKAGE\n"
+    printf "missing required argument: PACKAGE\nusage: rush get PACKAGE [options]\n"
     exit 1
   fi
   # :command.required_flags_filter
@@ -1942,6 +1959,12 @@ rush_get_parse_requirements() {
   while [[ $# -gt 0 ]]; do
     key="$1"
     case "$key" in
+    # :flag.case
+    --clone | -c )
+      args[--clone]=1
+      shift
+      ;;
+  
   
     -* )
       printf "invalid option: %s\n" "$key"

--- a/rush
+++ b/rush
@@ -200,6 +200,11 @@ rush_clone_usage() {
     echo "  --full, -f"
     printf "    Perform a full clone, instead of the default shallow clone\n"
     echo
+    
+    # :flag.usage
+    echo "  --ignore, -i"
+    printf "    Ignore (do not clone) if a repository with this name exists.\n"
+    echo
     # :command.usage_args
     printf "Arguments:\n"
     
@@ -218,7 +223,7 @@ rush_clone_usage() {
     
     printf "  rush clone bobby\n"
     printf "  rush clone bobby/bobs-repo ./repos/bobby --ssh\n"
-    printf "  rush clone bobby --name sample\n"
+    printf "  rush clone bobby --name sample --ignore\n"
     echo
 
   fi
@@ -376,7 +381,7 @@ rush_get_usage() {
   if [[ -n $long_usage ]]; then
     printf "rush get\n"
     echo 
-    printf "  Install a package\n  This command runs the main script in the package directory.\n"
+    printf "  Install a package\n  This command runs the main script in the package directory.\n  \n  This is the default command, which means that running 'rush package' is\n  the same as running 'rush get package'.\n"
     echo 
   else
     printf "rush get - Install a package\n"
@@ -409,6 +414,7 @@ rush_get_usage() {
     # :command.usage_examples
     printf "Examples:\n"
     
+    printf "  rush ruby\n"
     printf "  rush get ruby\n"
     printf "  rush get centos:ruby\n"
     echo
@@ -848,6 +854,17 @@ config_keys() {
   echo "${keys[@]}"
 }
 
+# Returns true if the specified key exists in the config file
+# Usage:
+#
+#   if config_has_key "key" ; then
+#     echo "key exists"
+#   fi
+#
+config_has_key() {
+  [[ $(config_get "$1") ]]
+}
+
 # :src/lib/is_busybox_grep.sh
 is_busybox_grep() {
   grep --version 2>&1 /dev/null | grep -i busybox > /dev/null 2>&1
@@ -896,6 +913,7 @@ rush_clone_command() {
   repo_id=${args[github_user]}
   use_ssh=${args[--ssh]}
   full=${args[--full]}
+  ignore=${args[--ignore]}
   default_repo_name=${repo_id%%/*}
   repo_name=${args[--name]:-$default_repo_name}
   
@@ -903,7 +921,7 @@ rush_clone_command() {
   [[ $repo_id = */* ]] || repo_id="$repo_id/rush-repo"
   
   # Set clone URL - ssh or https?
-  if [[ $use_ssh ]]; then
+  if [[ $use_ssh ]] ; then
     repo_url=git@github.com:$repo_id.git
   else
     repo_url=https://github.com/$repo_id.git
@@ -913,20 +931,41 @@ rush_clone_command() {
   [[ $path ]] || path="$HOME/rush-repos/$repo_id"
   
   # Abort if target directory exists
-  [[ -d $path ]] && abort "Directory $path already exists."
-  
-  set -e
-  
-  # Clone
-  say "clone" "$repo_url"
-  if [[ $full ]]; then
-    git clone "$repo_url" "$path"
-  else
-    git clone --depth 1 "$repo_url" "$path"
+  if [[ -d $path ]] ; then
+    if [[ $ignore ]] ; then
+      skip=1
+    else
+      abort "Directory $path already exists."
+    fi
   fi
   
-  # Save config
-  config_set "$repo_name" "$path"
+  # Abort if a repository with this name already exists
+  if config_has_key "$repo_name" ; then
+    if [[ $ignore ]] ; then
+      skip=1
+    else
+      abort "The repository is already registered:\n$repo_name = $(config_get "$repo_name")."
+    fi
+  fi
+  
+  if [[ $skip ]] ; then
+    say "clone" "skipping $repo_name (exists)"
+  
+  else
+    set -e
+  
+    # Clone
+    say "clone" "$repo_url"
+    if [[ $full ]]; then
+      git clone "$repo_url" "$path"
+    else
+      git clone --depth 1 "$repo_url" "$path"
+    fi
+  
+    # Save config
+    config_set "$repo_name" "$path"
+  
+  fi
 }
 
 # :command.function
@@ -1624,6 +1663,12 @@ rush_clone_parse_requirements() {
     # :flag.case
     --full | -f )
       args[--full]=1
+      shift
+      ;;
+  
+    # :flag.case
+    --ignore | -i )
+      args[--ignore]=1
       shift
       ;;
   

--- a/src/bashly.yml
+++ b/src/bashly.yml
@@ -161,6 +161,14 @@ commands:
       this case, the default repository will be used) or in the form of
       'repo:package'.
 
+  flags:
+  - long: --clone
+    short: -c
+    help: |-
+      Clone the repository if it is not found locally
+      This flag will look for a GitHub user with the same name as the
+      repository, and attempt to clone their rush-repo repository.
+
   examples:
   - rush ruby
   - rush get ruby

--- a/src/bashly.yml
+++ b/src/bashly.yml
@@ -1,6 +1,6 @@
 name: rush
 help: Personal package manager
-version: 0.5.0
+version: 0.5.1
 
 environment_variables:
 - name: rush_config

--- a/src/bashly.yml
+++ b/src/bashly.yml
@@ -84,10 +84,14 @@ commands:
     short: -f
     help: Perform a full clone, instead of the default shallow clone
 
+  - long: --ignore
+    short: -i
+    help: Ignore (do not clone) if a repository with this name exists.
+
   examples:
   - rush clone bobby
   - rush clone bobby/bobs-repo ./repos/bobby --ssh
-  - rush clone bobby --name sample
+  - rush clone bobby --name sample --ignore
 
 - name: pull
   short: p
@@ -142,6 +146,9 @@ commands:
   help: |-
     Install a package
     This command runs the main script in the package directory.
+    
+    This is the default command, which means that running 'rush package' is
+    the same as running 'rush get package'.
 
   default: true
 
@@ -155,6 +162,7 @@ commands:
       'repo:package'.
 
   examples:
+  - rush ruby
   - rush get ruby
   - rush get centos:ruby 
 

--- a/src/clone_command.sh
+++ b/src/clone_command.sh
@@ -42,10 +42,10 @@ if [[ $skip ]] ; then
   say "clone" "skipping $repo_name (exists)"
 
 else
-  set -e
-
   # Clone
   say "clone" "$repo_url"
+  github_repo_exist "$repo_id" || abort "cannot find $repo_id on github"
+
   if [[ $full ]]; then
     git clone "$repo_url" "$path"
   else

--- a/src/clone_command.sh
+++ b/src/clone_command.sh
@@ -3,6 +3,7 @@ path=${args[path]}
 repo_id=${args[github_user]}
 use_ssh=${args[--ssh]}
 full=${args[--full]}
+ignore=${args[--ignore]}
 default_repo_name=${repo_id%%/*}
 repo_name=${args[--name]:-$default_repo_name}
 
@@ -10,7 +11,7 @@ repo_name=${args[--name]:-$default_repo_name}
 [[ $repo_id = */* ]] || repo_id="$repo_id/rush-repo"
 
 # Set clone URL - ssh or https?
-if [[ $use_ssh ]]; then
+if [[ $use_ssh ]] ; then
   repo_url=git@github.com:$repo_id.git
 else
   repo_url=https://github.com/$repo_id.git
@@ -20,17 +21,38 @@ fi
 [[ $path ]] || path="$HOME/rush-repos/$repo_id"
 
 # Abort if target directory exists
-[[ -d $path ]] && abort "Directory $path already exists."
-
-set -e
-
-# Clone
-say "clone" "$repo_url"
-if [[ $full ]]; then
-  git clone "$repo_url" "$path"
-else
-  git clone --depth 1 "$repo_url" "$path"
+if [[ -d $path ]] ; then
+  if [[ $ignore ]] ; then
+    skip=1
+  else
+    abort "Directory $path already exists."
+  fi
 fi
 
-# Save config
-config_set "$repo_name" "$path"
+# Abort if a repository with this name already exists
+if config_has_key "$repo_name" ; then
+  if [[ $ignore ]] ; then
+    skip=1
+  else
+    abort "The repository is already registered:\n$repo_name = $(config_get "$repo_name")."
+  fi
+fi
+
+if [[ $skip ]] ; then
+  say "clone" "skipping $repo_name (exists)"
+
+else
+  set -e
+
+  # Clone
+  say "clone" "$repo_url"
+  if [[ $full ]]; then
+    git clone "$repo_url" "$path"
+  else
+    git clone --depth 1 "$repo_url" "$path"
+  fi
+
+  # Save config
+  config_set "$repo_name" "$path"
+
+fi

--- a/src/get_command.sh
+++ b/src/get_command.sh
@@ -1,10 +1,16 @@
 # Collect variables
 package=${args[package]}
 repo="default"
+clone=${args[--clone]}
 
 if [[ $package =~ (.*):(.*) ]]; then
   repo=${BASH_REMATCH[1]}
   package=${BASH_REMATCH[2]}
+fi
+
+if ! config_has_key "$repo" && [[ $clone ]] && [[ $repo != 'default' ]]; then
+  say "get" "repo $repo does not exist, attempting clone"
+  rush clone "$repo"
 fi
 
 repo_path=$(config_get "$repo")

--- a/src/lib/config.sh
+++ b/src/lib/config.sh
@@ -113,3 +113,14 @@ config_keys() {
   done < "$CONFIG_FILE"
   echo "${keys[@]}"
 }
+
+# Returns true if the specified key exists in the config file
+# Usage:
+#
+#   if config_has_key "key" ; then
+#     echo "key exists"
+#   fi
+#
+config_has_key() {
+  [[ $(config_get "$1") ]]
+}

--- a/src/lib/github_repo_exist.sh
+++ b/src/lib/github_repo_exist.sh
@@ -1,0 +1,5 @@
+# if github_repo_exist dannyben/rush-cli ; then ...
+github_repo_exist() {
+  repo="$1"
+  curl -s -o /dev/null -I -w "%{http_code}"  "https://api.github.com/repos/$repo" | grep 200 > /dev/null
+}

--- a/test/approvals/rush_clone_dannyben_dir_exist
+++ b/test/approvals/rush_clone_dannyben_dir_exist
@@ -1,0 +1,1 @@
+[31mDirectory /root/rush-repos/dannyben/rush-repo already exists.[0m

--- a/test/approvals/rush_clone_h
+++ b/test/approvals/rush_clone_h
@@ -22,6 +22,9 @@ Options:
   --full, -f
     Perform a full clone, instead of the default shallow clone
 
+  --ignore, -i
+    Ignore (do not clone) if a repository with this name exists.
+
 Arguments:
   GITHUB_USER
     Github user
@@ -35,4 +38,4 @@ Arguments:
 Examples:
   rush clone bobby
   rush clone bobby/bobs-repo ./repos/bobby --ssh
-  rush clone bobby --name sample
+  rush clone bobby --name sample --ignore

--- a/test/approvals/rush_clone_sample
+++ b/test/approvals/rush_clone_sample
@@ -1,0 +1,2 @@
+[31mThe repository is already registered:
+sample = /root/rush-repos/sample-repo.[0m

--- a/test/approvals/rush_clone_sample_ignore
+++ b/test/approvals/rush_clone_sample_ignore
@@ -1,0 +1,1 @@
+[35mclone[0m       | [1mskipping sample (exists)[0m

--- a/test/approvals/rush_get
+++ b/test/approvals/rush_get
@@ -1,2 +1,2 @@
 missing required argument: PACKAGE
-usage: rush get PACKAGE
+usage: rush get PACKAGE [options]

--- a/test/approvals/rush_get_dannyben_hello
+++ b/test/approvals/rush_get_dannyben_hello
@@ -1,0 +1,1 @@
+[31mrepo not found: dannyben[0m

--- a/test/approvals/rush_get_dannyben_hello_clone
+++ b/test/approvals/rush_get_dannyben_hello_clone
@@ -1,0 +1,8 @@
+[35mget[0m         | [1mrepo dannyben does not exist, attempting clone[0m
+[35mclone[0m       | [1mhttps://github.com/dannyben/rush-repo.git[0m
+Cloning into '/root/rush-repos/dannyben/rush-repo'...
+[35mget[0m         | [1mdannyben:hello[0m
+What's the rush?
+REPO:      dannyben
+REPO_PATH: /root/rush-repos/dannyben/rush-repo
+USER_CWD:  /test

--- a/test/approvals/rush_get_dannyben_hello_works
+++ b/test/approvals/rush_get_dannyben_hello_works
@@ -1,0 +1,5 @@
+[35mget[0m         | [1mdannyben:hello[0m
+What's the rush?
+REPO:      dannyben
+REPO_PATH: /root/rush-repos/dannyben/rush-repo
+USER_CWD:  /test

--- a/test/approvals/rush_get_h
+++ b/test/approvals/rush_get_h
@@ -9,12 +9,17 @@ rush get
 Shortcut: g
 
 Usage:
-  rush get PACKAGE
+  rush get PACKAGE [options]
   rush get --help | -h
 
 Options:
   --help, -h
     Show this help
+
+  --clone, -c
+    Clone the repository if it is not found locally
+    This flag will look for a GitHub user with the same name as the
+    repository, and attempt to clone their rush-repo repository.
 
 Arguments:
   PACKAGE

--- a/test/approvals/rush_get_h
+++ b/test/approvals/rush_get_h
@@ -2,6 +2,9 @@ rush get
 
   Install a package
   This command runs the main script in the package directory.
+  
+  This is the default command, which means that running 'rush package' is
+  the same as running 'rush get package'.
 
 Shortcut: g
 
@@ -21,5 +24,6 @@ Arguments:
     'repo:package'.
 
 Examples:
+  rush ruby
   rush get ruby
   rush get centos:ruby

--- a/test/approvals/rush_pull
+++ b/test/approvals/rush_pull
@@ -1,4 +1,4 @@
-[35mpull[0m        | [1mdannyben[0m
-Already up to date.
 [35mpull[0m        | [1mskipping default (not a git repo)[0m
 [35mpull[0m        | [1mskipping sample (not a git repo)[0m
+[35mpull[0m        | [1mdannyben[0m
+Already up to date.

--- a/test/approvals/rush_push
+++ b/test/approvals/rush_push
@@ -1,7 +1,7 @@
+[35mpush[0m        | [1mskipping default (not a git repo)[0m
+[35mpush[0m        | [1mskipping sample (not a git repo)[0m
 [35mpush[0m        | [1mdannyben[0m
 On branch master
 Your branch is up to date with 'origin/master'.
 
 nothing to commit, working tree clean
-[35mpush[0m        | [1mskipping default (not a git repo)[0m
-[35mpush[0m        | [1mskipping sample (not a git repo)[0m

--- a/test/approve
+++ b/test/approve
@@ -58,6 +58,10 @@ describe "get"
   approve "rush get sample:hello"
   approve "rush hello"
   approve "rush get package-in-package/one"
+  rush remove dannyben --purge > /dev/null
+  approve "rush get dannyben:hello"
+  approve "rush get dannyben:hello --clone"
+  approve "rush get dannyben:hello" "rush_get_dannyben_hello_works"
 
 describe "undo"
   approve "rush undo"

--- a/test/approve
+++ b/test/approve
@@ -26,10 +26,19 @@ describe "clone"
   count=$(cd /root/rush-repos/dannyben/rush-repo && git rev-list --count HEAD -n 10)
   [[ $count == 1 ]] || fail "Expected shallow clone, got $count commits"
 
-  rm -rf /root/rush-repos/dannyben
+  rush remove dannyben --purge >/dev/null
   approve "rush clone dannyben --full"
   count=$(cd /root/rush-repos/dannyben/rush-repo && git rev-list --count HEAD -n 10)
   [[ $count == 10 ]] || fail "Expected full clone, got $count commits"
+
+  approve "rush clone dannyben" "rush_clone_dannyben_dir_exist"
+  expect_exit_code 1
+
+  approve "rush clone sample"
+  expect_exit_code 1
+
+  approve "rush clone sample --ignore"
+  expect_exit_code 0
 
 describe "config"
   approve "rush config"


### PR DESCRIPTION
- Add `--ignore` flag to `rush clone`. If provided, we will not consider it an error if the repo already exists, we will simply avoid cloning. This is intended to allow scripts to just `rush clone --ignore` without first checking if it exists.
- Add another abort condition to `rush clone`: Abort if repo is already registered.
- Improve `rush get` help text, to explain it is the default command.
- Add `--clone` flag to `rush get`. If provided, and in case the package is in the form of `repo:package`, and the repo is not found locally, we will attempt to run `rush clone $repo` (which looks for the GitHub user with the same name as the repo, and their `rush-repo` repository).