### PR TITLE
Fix list command

### DIFF
--- a/rush
+++ b/rush
@@ -844,7 +844,7 @@ config_show() {
 #   done
 #
 config_keys() {
-  regex="^(.*)\s*="
+  regex="^([a-zA-Z0-9_\-]+)\s*="
 
   config_init
 
@@ -1218,9 +1218,10 @@ rush_list_command() {
   }
   
   list_show_repo() {
-    repo_or_package="$1"
-    search="${args[--search]}"
-    repo="$repo_or_package"
+    local repo_or_package="$1"
+    local search="${args[--search]}"
+    local repo="$repo_or_package"
+    local package glob repo_path infofile regex package_name
   
     if [[ $repo_or_package =~ (.*):(.*) ]]; then
       repo=${BASH_REMATCH[1]}

--- a/src/lib/config.sh
+++ b/src/lib/config.sh
@@ -100,7 +100,7 @@ config_show() {
 #   done
 #
 config_keys() {
-  regex="^(.*)\s*="
+  regex="^([a-zA-Z0-9_\-]+)\s*="
 
   config_init
 

--- a/src/list_command.sh
+++ b/src/list_command.sh
@@ -14,9 +14,10 @@ list_display_item() {
 }
 
 list_show_repo() {
-  repo_or_package="$1"
-  search="${args[--search]}"
-  repo="$repo_or_package"
+  local repo_or_package="$1"
+  local search="${args[--search]}"
+  local repo="$repo_or_package"
+  local package glob repo_path infofile regex package_name
 
   if [[ $repo_or_package =~ (.*):(.*) ]]; then
     repo=${BASH_REMATCH[1]}

--- a/test/approvals/rush_list
+++ b/test/approvals/rush_list
@@ -10,5 +10,14 @@ This is a simple example.
 [32mnested[0m
 Nested packages (show with 'rush list nested')
 
-[32msample:nested/hi[0m
-Shows how to use nested folders
+[32msample:bootstrap[0m
+Shows how to run another command from the same repository
+
+[32msample:download[0m
+Shows how a script can copy files from its own folder
+
+[32msample:hello[0m
+This is a simple example.
+
+[32msample:nested[0m
+Nested packages (show with 'rush list nested')

--- a/test/approvals/rush_list_simple
+++ b/test/approvals/rush_list_simple
@@ -2,4 +2,7 @@ bootstrap
 download
 hello
 nested
-sample:nested/hi
+sample:bootstrap
+sample:download
+sample:hello
+sample:nested


### PR DESCRIPTION
- When running `rush list` with several repos, there was sometimes an error `no matches` - this was due to the fact that some local variables in a function were remembered across calls. Declared them all local.
- Updated the bashly config stdlib to allow comments in the INI file.