### PR TITLE
Fix rush clone for private repos

### DIFF
--- a/rush
+++ b/rush
@@ -869,13 +869,6 @@ config_has_key() {
   [[ $(config_get "$1") ]]
 }
 
-# :src/lib/github_repo_exist.sh
-# if github_repo_exist dannyben/rush-cli ; then ...
-github_repo_exist() {
-  repo="$1"
-  curl -s -o /dev/null -I -w "%{http_code}"  "https://api.github.com/repos/$repo" | grep 200 > /dev/null
-}
-
 # :src/lib/is_busybox_grep.sh
 is_busybox_grep() {
   grep --version 2>&1 /dev/null | grep -i busybox > /dev/null 2>&1
@@ -951,7 +944,7 @@ rush_clone_command() {
     if [[ $ignore ]] ; then
       skip=1
     else
-      abort "Directory $path already exists."
+      abort "directory $path already exists."
     fi
   fi
   
@@ -960,7 +953,7 @@ rush_clone_command() {
     if [[ $ignore ]] ; then
       skip=1
     else
-      abort "The repository is already registered:\n$repo_name = $(config_get "$repo_name")."
+      abort "the repository is already registered:\n$repo_name = $(config_get "$repo_name")."
     fi
   fi
   
@@ -970,7 +963,6 @@ rush_clone_command() {
   else
     # Clone
     say "clone" "$repo_url"
-    github_repo_exist "$repo_id" || abort "cannot find $repo_id on github"
   
     if [[ $full ]]; then
       git clone "$repo_url" "$path"
@@ -1343,7 +1335,7 @@ rush_search_command() {
   }
   
   if is_busybox_grep; then
-    abort "Cannot run with BusyBox grep.\nPlease install GNU grep:\napk add --no-cache grep"
+    abort "cannot run with BusyBox grep.\nplease install GNU grep:\napk add --no-cache grep"
   fi
   
   text=${args[text]}

--- a/src/clone_command.sh
+++ b/src/clone_command.sh
@@ -25,7 +25,7 @@ if [[ -d $path ]] ; then
   if [[ $ignore ]] ; then
     skip=1
   else
-    abort "Directory $path already exists."
+    abort "directory $path already exists."
   fi
 fi
 
@@ -34,7 +34,7 @@ if config_has_key "$repo_name" ; then
   if [[ $ignore ]] ; then
     skip=1
   else
-    abort "The repository is already registered:\n$repo_name = $(config_get "$repo_name")."
+    abort "the repository is already registered:\n$repo_name = $(config_get "$repo_name")."
   fi
 fi
 
@@ -44,7 +44,6 @@ if [[ $skip ]] ; then
 else
   # Clone
   say "clone" "$repo_url"
-  github_repo_exist "$repo_id" || abort "cannot find $repo_id on github"
 
   if [[ $full ]]; then
     git clone "$repo_url" "$path"

--- a/src/lib/github_repo_exist.sh
+++ b/src/lib/github_repo_exist.sh
@@ -1,5 +1,0 @@
-# if github_repo_exist dannyben/rush-cli ; then ...
-github_repo_exist() {
-  repo="$1"
-  curl -s -o /dev/null -I -w "%{http_code}"  "https://api.github.com/repos/$repo" | grep 200 > /dev/null
-}

--- a/src/search_command.sh
+++ b/src/search_command.sh
@@ -23,7 +23,7 @@ search_repo() {
 }
 
 if is_busybox_grep; then
-  abort "Cannot run with BusyBox grep.\nPlease install GNU grep:\napk add --no-cache grep"
+  abort "cannot run with BusyBox grep.\nPlease install GNU grep:\napk add --no-cache grep"
 fi
 
 text=${args[text]}

--- a/test/approvals/rush_clone_dannyben_dir_exist
+++ b/test/approvals/rush_clone_dannyben_dir_exist
@@ -1,1 +1,1 @@
-[31mDirectory /root/rush-repos/dannyben/rush-repo already exists.[0m
+[31mdirectory /root/rush-repos/dannyben/rush-repo already exists.[0m

--- a/test/approvals/rush_clone_sample
+++ b/test/approvals/rush_clone_sample
@@ -1,2 +1,2 @@
-[31mThe repository is already registered:
+[31mthe repository is already registered:
 sample = /root/rush-repos/sample-repo.[0m

--- a/test/approvals/rush_search_busybox_error
+++ b/test/approvals/rush_search_busybox_error
@@ -1,3 +1,3 @@
-[31mCannot run with BusyBox grep.
-Please install GNU grep:
+[31mcannot run with BusyBox grep.
+please install GNU grep:
 apk add --no-cache grep[0m


### PR DESCRIPTION
The function that checks if a github repo exists prior to allowing `rush clone` used `curl` to test it, which does not work on private repos. It was removed.