### PR TITLE
Change push command to only push the default

### DIFF
--- a/rush
+++ b/rush
@@ -295,6 +295,11 @@ rush_push_usage() {
     echo
     # :command.usage_flags
     # :flag.usage
+    echo "  --all, -a"
+    printf "    Push all repositories.\n"
+    echo
+    
+    # :flag.usage
     echo "  --message, -m TEXT"
     printf "    Commit message.\n    Default: automatic commit\n"
     echo
@@ -303,7 +308,7 @@ rush_push_usage() {
     
     # :argument.usage
     echo "  REPO"
-    printf "    Repository name.\n"
+    printf "    Repository name.\n    Default: default\n"
     echo
 
   fi
@@ -1060,7 +1065,8 @@ rush_pull_command() {
 rush_push_command() {
   # :src/push_command.sh
   set +e
-  repo=${args[repo]}
+  all=${args[--all]}
+  repo=${args[repo]:-default}
   message=${args[--message]:-"automatic commit"}
   
   push_repo() {
@@ -1082,14 +1088,14 @@ rush_push_command() {
     fi
   }
   
-  if [[ $repo ]]; then
-    repo_path=$(config_get "$repo")
-    [[ $repo_path ]] || abort "no such repo: $repo"
-    push_repo "$repo_path" "$repo"
-  else
+  if [[ $all ]]; then
     for k in $(config_keys); do
       push_repo "$(config_get "$k")" "$k"
     done
+  else
+    repo_path=$(config_get "$repo")
+    [[ $repo_path ]] || abort "no such repo: $repo"
+    push_repo "$repo_path" "$repo"
   fi
 }
 
@@ -1912,6 +1918,12 @@ rush_push_parse_requirements() {
   while [[ $# -gt 0 ]]; do
     key="$1"
     case "$key" in
+    # :flag.case
+    --all | -a )
+      args[--all]=1
+      shift
+      ;;
+  
     # :flag.case
     --message | -m )
       if [[ $2 ]]; then

--- a/src/bashly.yml
+++ b/src/bashly.yml
@@ -111,9 +111,15 @@ commands:
 
   args:
   - name: repo
-    help: Repository name.
+    help: |-
+      Repository name.
+      Default: default
 
   flags:
+  - long: --all
+    short: -a
+    help: Push all repositories.
+
   - long: --message
     short: -m
     arg: TEXT

--- a/src/push_command.sh
+++ b/src/push_command.sh
@@ -1,5 +1,6 @@
 set +e
-repo=${args[repo]}
+all=${args[--all]}
+repo=${args[repo]:-default}
 message=${args[--message]:-"automatic commit"}
 
 push_repo() {
@@ -21,13 +22,13 @@ push_repo() {
   fi
 }
 
-if [[ $repo ]]; then
-  repo_path=$(config_get "$repo")
-  [[ $repo_path ]] || abort "no such repo: $repo"
-  push_repo "$repo_path" "$repo"
-else
+if [[ $all ]]; then
   for k in $(config_keys); do
     push_repo "$(config_get "$k")" "$k"
   done
+else
+  repo_path=$(config_get "$repo")
+  [[ $repo_path ]] || abort "no such repo: $repo"
+  push_repo "$repo_path" "$repo"
 fi
 

--- a/test/approvals/rush_push
+++ b/test/approvals/rush_push
@@ -1,7 +1,1 @@
 [35mpush[0m        | [1mskipping default (not a git repo)[0m
-[35mpush[0m        | [1mskipping sample (not a git repo)[0m
-[35mpush[0m        | [1mdannyben[0m
-On branch master
-Your branch is up to date with 'origin/master'.
-
-nothing to commit, working tree clean

--- a/test/approvals/rush_push_all
+++ b/test/approvals/rush_push_all
@@ -1,0 +1,7 @@
+[35mpush[0m        | [1mskipping default (not a git repo)[0m
+[35mpush[0m        | [1mskipping sample (not a git repo)[0m
+[35mpush[0m        | [1mdannyben[0m
+On branch master
+Your branch is up to date with 'origin/master'.
+
+nothing to commit, working tree clean

--- a/test/approvals/rush_push_dannyben
+++ b/test/approvals/rush_push_dannyben
@@ -1,0 +1,5 @@
+[35mpush[0m        | [1mdannyben[0m
+On branch master
+Your branch is up to date with 'origin/master'.
+
+nothing to commit, working tree clean

--- a/test/approvals/rush_push_h
+++ b/test/approvals/rush_push_h
@@ -8,6 +8,9 @@ Options:
   --help, -h
     Show this help
 
+  --all, -a
+    Push all repositories.
+
   --message, -m TEXT
     Commit message.
     Default: automatic commit
@@ -15,3 +18,4 @@ Options:
 Arguments:
   REPO
     Repository name.
+    Default: default

--- a/test/approve
+++ b/test/approve
@@ -95,6 +95,8 @@ describe "pull"
 
 describe "push"
   approve "rush push"
+  approve "rush push dannyben"
+  approve "rush push --all"
   approve "rush push -h"
 
 describe "remove"


### PR DESCRIPTION
### Change

- The command `rush push` will no longer push all local repositories, instead, it will only push the `default` one.
- In order to push all repositories, a new flag was added: `rush push --all`.

### Rationale

In most circumstances, users will have at most one repository that they have push privileges for, and the rest (if any) will be repositories that belong to other users.